### PR TITLE
Remove tracked env secrets and document secure handling

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-GEMINI_API_KEY=IzaSyB3cyCKVkN8MzrdfLtvNKHfLyqX6ef-gTQ

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ dist
 dist-ssr
 *.local
 
+# Environment variables
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ This repository now contains a minimal FastAPI backend with a React/Vite front-e
 - Python 3.10+
 - (Optional) Docker & Docker Compose
 
+## Environment configuration
+
+- Generate a new **GEMINI_API_KEY** in your Google Cloud project and revoke any previously exposed keys.
+- Provide the key to the application via environment variables instead of committing it to the repository.
+  - For local development you can create an `.env` file (ignored by Git) containing `GEMINI_API_KEY=<your-new-key>`.
+  - Alternatively, export the variable in your shell session before starting the services: `export GEMINI_API_KEY=<your-new-key>`.
+- In automated environments (Docker, CI/CD, hosting providers), inject the variable using the platform's secret manager or runtime configuration features.
+
 ## Backend setup
 
 1. Install dependencies:

--- a/TESTING_AND_DEPLOYMENT.md
+++ b/TESTING_AND_DEPLOYMENT.md
@@ -162,16 +162,13 @@ networks:
 _Note: For production, the frontend would typically handle proxying `/api` requests to the backend container, so only the frontend port needs to be exposed to the public._
 
 ### 3.5. Environment Variable Management
--   Sensitive information, such as the `API_KEY` for the Gemini API, must not be hardcoded.
--   A `.env` file will be created in the project's root directory to store these variables.
--   **Example `.env` file:**
-    ```
-    # Environment variables for the backend service
-    API_KEY="your-google-gemini-api-key-here"
-    ```
--   This `.env` file will be loaded by the `backend` service in `docker-compose.yml`.
--   **Crucially, the `.env` file must be added to `.gitignore`** to prevent secrets from being committed to version control.
-```
-# .gitignore
-.env
-```
+-   Sensitive information, such as the `GEMINI_API_KEY`, must never be hardcoded or committed to the repository.
+-   Revoke compromised keys immediately in the Google Cloud console and generate replacements as needed.
+-   Provide secrets to the application through runtime environment variables:
+    -   For local development, create a personal `.env` file (ignored by Git) containing:
+        ```
+        GEMINI_API_KEY="your-rotated-google-gemini-api-key"
+        ```
+        This file should be created manually on each developer machine after retrieving the key from your secrets manager.
+    -   In containerized or hosted environments, inject the variable via the platform's secret management features instead of copying files into the image.
+-   Confirm that `.env` files remain excluded from version control via `.gitignore`.


### PR DESCRIPTION
## Summary
- remove the tracked .env file and ignore local environment secrets
- document rotating the GEMINI_API_KEY and loading it via environment variables

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d7fec781fc832daa3fca6cf773c06b