### PR TITLE
Document Docker Compose development and production usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ The app runs on `http://localhost:3000` and proxies `/api` requests to the backe
 
 ## Run with Docker Compose
 
-To start both services with Docker Compose:
+### Development
+
+To iterate locally with hot-reload enabled, start the stack with the default Compose file:
 
 ```bash
 docker compose up --build
@@ -102,7 +104,17 @@ docker compose up --build
 - Backend: exposed at `http://localhost:8000`
 - Frontend dev server: `http://localhost:3000`
 
-Volumes are mounted for live reloading during development. Provide environment variables through an `.env` file in the project root before running the stack.
+Both services mount the repository directory (`.:/app` in `docker-compose.yml`) so code changes are reflected without rebuilding. Place your development secrets—at minimum `GEMINI_API_KEY=<value>`—in an `.env` file at the project root so the backend container picks them up via the `env_file` directive.
+
+### Production
+
+For production deployments you typically want to run the built images without the development bind mounts. Create a production override (for example, `docker-compose.prod.yml`) that removes the `.:/app` volumes and sets any production-only configuration, or add a `production` profile to your Compose file. Then launch the stack in detached mode:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d
+```
+
+Ensure your production environment provides the same required variables—especially `GEMINI_API_KEY`—either through an override `env_file` (such as `.env.production`) or your orchestration platform's secret manager before starting the services.
 
 ## Deployment notes
 


### PR DESCRIPTION
## Summary
- split the README Docker Compose instructions into development and production workflows
- document the bind-mount hot reload setup and required environment variables for each mode
- add guidance for launching a production stack without development volumes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8105d2d30832da30333efb0a94d12