### PR TITLE
Add Vitest configuration and frontend workflow tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,13 @@ curl -sS -X POST http://localhost:8000/api/v1/workflow/run \
 
 When you are finished, you can remove the temporary files with `rm -r smoke-tests`.
 
-## Testing (future work)
+## Testing
 
-Unit tests and CI pipelines are not yet configured. Recommended next steps include adding pytest coverage for the execution engine and Vitest/RTL coverage for critical frontend interactions.
+The frontend includes Vitest suites that cover critical workflow interactions such as uploading datasets, saving/loading workflows, and executing a run. To install dependencies and run the tests locally:
+
+```bash
+npm install
+npm run test
+```
+
+Vitest will use a mocked backend (via MSW) so no API services need to be running for these checks.

--- a/index.tsx
+++ b/index.tsx
@@ -197,6 +197,7 @@ const DataHubConfigurator = ({ onSelectDataset }) => {
                     <input
                         ref={fileInputRef}
                         type="file"
+                        aria-label="Dataset file input"
                         onChange={handleFileUpload}
                         style={{ display: 'none' }}
                     />
@@ -472,7 +473,7 @@ const Toolbar = ({ onRun, onSave, onLoad, onClear }) => (
 
 
 // --- MAIN APP COMPONENT ---
-const App = () => {
+export const App = () => {
     const [nodes, setNodes] = useState([]);
     const [edges, setEdges] = useState([]);
     const [draggedItem, setDraggedItem] = useState(null);
@@ -841,6 +842,10 @@ const App = () => {
     );
 };
 
-const container = document.getElementById('root');
-const root = createRoot(container);
-root.render(<App />);
+if (typeof document !== 'undefined') {
+    const container = document.getElementById('root');
+    if (container) {
+        const root = createRoot(container);
+        root.render(<App />);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,16 @@
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
+        "@types/testing-library__jest-dom": "^6.0.0",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.5.2",
         "@vitejs/plugin-react": "^5.0.0",
+        "jsdom": "^24.1.3",
+        "msw": "^2.6.1",
         "typescript": "~5.8.2",
-        "vite": "^6.2.0"
+        "vite": "^6.2.0",
+        "vitest": "^2.1.3"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -15,7 +16,14 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
+    "@types/testing-library__jest-dom": "^6.0.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "jsdom": "^24.1.3",
+    "msw": "^2.6.1",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^2.1.3"
   }
 }

--- a/src/__tests__/run-workflow.test.tsx
+++ b/src/__tests__/run-workflow.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { App } from '@/index';
+import { server } from './setup';
+import { addModuleToCanvas } from './test-utils';
+
+describe('run workflow flow', () => {
+  test('runs the workflow and displays the run identifier', async () => {
+    let runPayload: any = null;
+
+    server.use(
+      http.post('/api/v1/workflow/run', async ({ request }) => {
+        runPayload = await request.json();
+        const responseNodes = (runPayload?.nodes ?? []).map((node: any) => ({
+          ...node,
+          status: 'completed',
+        }));
+        return HttpResponse.json({
+          run_id: 'run-123',
+          nodes: responseNodes,
+          edges: runPayload?.edges ?? [],
+        });
+      })
+    );
+
+    render(<App />);
+    await addModuleToCanvas('Text Input');
+
+    const runButton = screen.getByRole('button', { name: /Run/i });
+    await userEvent.click(runButton);
+
+    await screen.findByText(/Last run ID: run-123/i);
+
+    await waitFor(() => {
+      expect(runPayload?.nodes).toHaveLength(1);
+      const completedNode = document.querySelector('.node.status-completed');
+      expect(completedNode).not.toBeNull();
+    });
+  });
+});

--- a/src/__tests__/save-load-workflow.test.tsx
+++ b/src/__tests__/save-load-workflow.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { vi } from 'vitest';
+import { App } from '@/index';
+import { server } from './setup';
+import { addModuleToCanvas } from './test-utils';
+
+describe('save and load workflow flow', () => {
+  test('saves the current workflow and loads a saved workflow', async () => {
+    const promptMock = vi.spyOn(window, 'prompt').mockReturnValue('My workflow');
+    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+    let savedPayload: any = null;
+
+    server.use(
+      http.post('/api/v1/workflows/save', async ({ request }) => {
+        savedPayload = await request.json();
+        return HttpResponse.json({ id: 'workflow-1' });
+      }),
+      http.get('/api/v1/workflows', () =>
+        HttpResponse.json([
+          {
+            id: 'workflow-1',
+            name: 'Workflow 1',
+          },
+        ])
+      ),
+      http.get('/api/v1/workflows/workflow-1', () =>
+        HttpResponse.json({
+          nodes: [
+            {
+              id: 'node-loaded',
+              type: 'data_hub',
+              x: 120,
+              y: 120,
+              data: { datasetName: 'Loaded dataset' },
+            },
+          ],
+          edges: [],
+        })
+      )
+    );
+
+    render(<App />);
+    await addModuleToCanvas('Text Input');
+
+    const toolbar = document.querySelector('.canvas-toolbar') as HTMLElement;
+    const saveButton = within(toolbar).getByRole('button', { name: /^Save$/i });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(promptMock).toHaveBeenCalled();
+      expect(alertMock).toHaveBeenCalledWith('Workflow saved successfully!');
+      expect(savedPayload?.nodes).toHaveLength(1);
+    });
+
+    const loadButton = within(toolbar).getByRole('button', { name: /^Load$/i });
+    await userEvent.click(loadButton);
+
+    const modalHeading = await screen.findByRole('heading', { name: 'Load Workflow' });
+    const modal = modalHeading.closest('.modal-content');
+    if (!modal) {
+      throw new Error('Modal container not found');
+    }
+
+    const workflowLoadButton = within(modal).getByRole('button', { name: /^Load$/i });
+    await userEvent.click(workflowLoadButton);
+
+    await screen.findByText('Loaded dataset');
+  });
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,14 @@
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { setupServer } from 'msw/node';
+
+export const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  cleanup();
+  vi.restoreAllMocks();
+});
+afterAll(() => server.close());

--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -1,0 +1,47 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+type MutableDataTransfer = {
+  data: Record<string, string>;
+  setData: (type: string, value: string) => void;
+  getData: (type: string) => string;
+  clearData: () => void;
+  dropEffect: string;
+  effectAllowed: string;
+  files: File[];
+  items: DataTransferItem[];
+  types: string[];
+};
+
+export const createDataTransfer = (): DataTransfer => {
+  const store: Record<string, string> = {};
+  const dataTransfer: Partial<MutableDataTransfer> = {
+    data: store,
+    setData: (type: string, value: string) => {
+      store[type] = value;
+    },
+    getData: (type: string) => store[type] ?? '',
+    clearData: () => {
+      Object.keys(store).forEach((key) => delete store[key]);
+    },
+    dropEffect: 'move',
+    effectAllowed: 'all',
+    files: [],
+    items: [] as unknown as DataTransferItem[],
+    types: [],
+  };
+
+  return dataTransfer as DataTransfer;
+};
+
+export const addModuleToCanvas = async (label: string) => {
+  const module = await screen.findByText(label);
+  const canvas = document.querySelector('.canvas-area') as HTMLElement;
+  if (!canvas) {
+    throw new Error('Canvas element not found');
+  }
+
+  const dataTransfer = createDataTransfer();
+  fireEvent.dragStart(module, { dataTransfer });
+  fireEvent.dragOver(canvas, { dataTransfer });
+  fireEvent.drop(canvas, { dataTransfer });
+};

--- a/src/__tests__/upload-dataset.test.tsx
+++ b/src/__tests__/upload-dataset.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { App } from '@/index';
+import { server } from './setup';
+import { addModuleToCanvas } from './test-utils';
+
+describe('upload dataset flow', () => {
+  test('uploads a new dataset and refreshes the list', async () => {
+    let uploadCount = 0;
+
+    server.use(
+      http.get('/api/v1/datasets', () => {
+        if (uploadCount > 0) {
+          return HttpResponse.json([
+            {
+              id: 'dataset-1',
+              name: 'Uploaded Dataset',
+              type: 'image',
+              preview: '/preview.png',
+            },
+          ]);
+        }
+        return HttpResponse.json([]);
+      }),
+      http.post('/api/v1/datasets/upload', async () => {
+        uploadCount += 1;
+        return HttpResponse.json({ success: true });
+      })
+    );
+
+    render(<App />);
+    await addModuleToCanvas('Data Hub');
+
+    const configureButton = await screen.findByRole('button', { name: /configure dataset/i });
+    await userEvent.click(configureButton);
+
+    const modalHeading = await screen.findByRole('heading', { name: 'Data Hub' });
+    const modal = modalHeading.closest('.modal-content');
+    if (!modal) {
+      throw new Error('Modal container not found');
+    }
+
+    const fileInput = within(modal).getByLabelText('Dataset file input');
+    const file = new File(['id,value\n1,foo'], 'dataset.csv', { type: 'text/csv' });
+    await userEvent.upload(fileInput, file);
+
+    await screen.findByText('Uploaded Dataset');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "vitest/globals"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import path from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/__tests__/setup.ts'],
+    css: false,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest, Testing Library, and MSW dependencies plus a Vitest config aligned with the Vite aliases
- export the app component for testing and add accessibility for the dataset uploader
- create mocked workflow interaction test suites for uploading datasets, saving/loading, and running workflows, and document how to run them in the README

## Testing
- npm run test -- --run *(fails: vitest binary not installed in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8150e63ec832d8013c06703e7a861