### PR TITLE
Add CI workflow for Node and Python projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,117 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality-checks:
+    name: Lint, build, and test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Run frontend lint
+        run: npm run lint
+
+      - name: Run frontend tests
+        run: npm run test
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run pytest
+        run: pytest --maxfail=1 --disable-warnings
+
+      - name: Upload frontend coverage
+        if: always() && hashFiles('coverage/lcov.info') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: coverage/lcov.info
+
+      - name: Upload backend coverage
+        if: always() && hashFiles('coverage.xml') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: coverage.xml
+
+  docker-images:
+    name: Build and publish Docker images
+    needs: quality-checks
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - image: backend
+            file: Dockerfile.backend
+          - image: frontend
+            file: Dockerfile.frontend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}-${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push ${{ matrix.image }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.file }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -122,6 +122,25 @@ Ensure your production environment provides the same required variables—especi
 - Frontend production builds can be created with `npm run build` and served via a static host or reverse proxy (e.g., Nginx) that forwards `/api` traffic to the backend service.
 - Persist the `storage/` directory in production to retain datasets, workflows, and logs.
 
+## Continuous integration
+
+A GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push and pull request to keep the repository healthy:
+
+- Node.js 20 is provisioned, `npm ci` installs dependencies, and the frontend must pass `npm run lint` (TypeScript type-checking) and `npm run test` (a production Vite build).
+- Python 3.11 is provisioned, `pip` installs the dependencies defined in `requirements-dev.txt`, and the backend must pass `pytest`.
+- Dependency installs for both runtimes are cached automatically to speed up subsequent runs.
+- Coverage and other build artefacts are uploaded when generated so they are easy to inspect from a workflow run.
+- When the workflow runs on the `main` branch or a tagged release (and not for pull requests), Docker images for the backend and frontend are built and pushed to GitHub Container Registry using the repository's `GITHUB_TOKEN`.
+
+Before opening a pull request, run the same commands locally so CI succeeds:
+
+```bash
+npm run lint
+npm run test
+python -m pip install -r requirements-dev.txt
+pytest
+```
+
 ## Smoke tests
 
 After completing the backend setup, ensure the API is running at `http://localhost:8000`. The commands below assume `curl` (and optionally [`jq`](https://stedolan.github.io/jq/)) is available on your PATH.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "lint": "tsc --noEmit",
+    "test": "vite build --mode test",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that caches dependencies, runs npm lint/test, runs pytest, and publishes Docker images from main or tags
- add a requirements-dev.txt helper for installing pytest and expose lint/test scripts in package.json
- document the new CI requirements in the README so contributors know which commands to run locally

## Testing
- npm run lint *(fails: existing TypeScript syntax markers in index.tsx)*
- npm run test *(fails: existing TypeScript syntax markers in index.tsx)*
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d8150f7874832da8f383bd4e86b099