### PR TITLE
Update Vite env loading to respect VITE-prefixed variables

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,8 @@ import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, '.', '');
-  const apiTarget = env.VITE_API_TARGET || 'http://localhost:8000';
+  const { VITE_API_TARGET } = loadEnv(mode, process.cwd());
+  const apiTarget = VITE_API_TARGET || process.env.VITE_API_TARGET || 'http://localhost:8000';
 
   return {
     server: {


### PR DESCRIPTION
## Summary
- load Vite environment variables with process.cwd() so only VITE_ prefixed values are exposed
- destructure VITE_API_TARGET from the environment and fall back to process.env

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d89f7cc338832d937b5ec7c1c41a19