### PR TITLE
Add toast notifications for API feedback

### DIFF
--- a/index.css
+++ b/index.css
@@ -581,3 +581,91 @@ html, body {
     height: 100%;
     object-fit: cover;
 }
+
+.empty-state {
+    padding: 1.25rem;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    background-color: var(--bg-color);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.empty-state h4,
+.toast-card h4 {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.empty-state p,
+.toast-card p {
+    font-size: 0.9rem;
+    color: var(--text-secondary-color);
+}
+
+.empty-state-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.toast-viewport {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    z-index: 1200;
+    pointer-events: none;
+}
+
+.toast-card {
+    pointer-events: auto;
+    min-width: 260px;
+    max-width: 360px;
+    background-color: var(--surface-color);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+}
+
+.toast-card.toast-success {
+    border-left: 4px solid var(--success-color);
+}
+
+.toast-card.toast-error {
+    border-left: 4px solid var(--error-color);
+}
+
+.toast-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    flex: 1;
+}
+
+.toast-copy h4,
+.toast-copy p {
+    margin: 0;
+}
+
+.toast-dismiss-btn {
+    background: none;
+    border: none;
+    color: var(--text-secondary-color);
+    cursor: pointer;
+    padding: 0.25rem;
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
+.toast-dismiss-btn:hover {
+    color: var(--text-color);
+}

--- a/index.tsx
+++ b/index.tsx
@@ -4,9 +4,45 @@ import { createRoot } from 'react-dom/client';
 
 const DEFAULT_ERROR_MESSAGE = 'Request failed, please retry.';
 
-const handleApiError = (error, fallbackMessage = DEFAULT_ERROR_MESSAGE, context = 'API request failed') => {
+const TOAST_DURATION = 5000;
+
+const ToastContext = React.createContext(() => {});
+
+const useToast = () => React.useContext(ToastContext);
+
+const ToastViewport = ({ toasts, onDismiss }) => (
+    <div className="toast-viewport" role="region" aria-live="polite" aria-atomic="true" aria-label="Notifications">
+        {toasts.map((toast) => (
+            <div
+                key={toast.id}
+                className={`toast-card toast-${toast.tone}`}
+                role={toast.tone === 'error' ? 'alert' : 'status'}
+                aria-live={toast.tone === 'error' ? 'assertive' : 'polite'}
+            >
+                <div className="toast-copy">
+                    <h4>{toast.title}</h4>
+                    {toast.description ? <p>{toast.description}</p> : null}
+                </div>
+                <button
+                    type="button"
+                    className="toast-dismiss-btn"
+                    onClick={() => onDismiss(toast.id)}
+                    aria-label="Dismiss notification"
+                >
+                    <Icons.Close />
+                </button>
+            </div>
+        ))}
+    </div>
+);
+
+const handleApiError = (enqueueToast, error, fallbackMessage = DEFAULT_ERROR_MESSAGE, context = 'API request failed') => {
     console.error(context, error);
-    alert(fallbackMessage);
+    enqueueToast({
+        tone: 'error',
+        title: 'We hit a snag',
+        description: fallbackMessage,
+    });
 };
 
 // --- ICONS ---
@@ -60,43 +96,26 @@ const Modal = ({ isOpen, onClose, title, children }) => {
 };
 
 const ModelHubConfigurator = ({ onSelectModel }) => {
+    const enqueueToast = useToast();
     const [models, setModels] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
     const [searchTerm, setSearchTerm] = useState('');
 
-codex/add-empty-state-handling-for-various-components
     const fetchModels = useCallback(async () => {
         try {
             setIsLoading(true);
             const response = await fetch('/api/v1/models');
             if (!response.ok) {
                 throw new Error('Network response was not ok');
-
-    useEffect(() => {
-        const fetchModels = async () => {
-            try {
-                setIsLoading(true);
-                const response = await fetch('/api/v1/models');
-                if (!response.ok) {
-                    throw new Error('Network response was not ok');
-                }
-                const data = await response.json();
-                setModels(data);
-            } catch (error) {
-                handleApiError(error, DEFAULT_ERROR_MESSAGE, 'Failed to fetch models');
-            } finally {
-                setIsLoading(false);
-main
             }
             const data = await response.json();
             setModels(data);
         } catch (error) {
-            console.error("Failed to fetch models:", error);
-            alert("Could not fetch models from the server.");
+            handleApiError(enqueueToast, error, DEFAULT_ERROR_MESSAGE, 'Failed to fetch models');
         } finally {
             setIsLoading(false);
         }
-    }, []);
+    }, [enqueueToast]);
 
     useEffect(() => {
         fetchModels();
@@ -141,26 +160,27 @@ main
 };
 
 const DataHubConfigurator = ({ onSelectDataset }) => {
+    const enqueueToast = useToast();
     const [datasets, setDatasets] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
     const fileInputRef = useRef(null);
 
-    const fetchDatasets = async () => {
+    const fetchDatasets = useCallback(async () => {
         try {
             setIsLoading(true);
             const response = await fetch('/api/v1/datasets');
             const data = await response.json();
             setDatasets(data);
         } catch (error) {
-            handleApiError(error, DEFAULT_ERROR_MESSAGE, 'Failed to fetch datasets');
+            handleApiError(enqueueToast, error, DEFAULT_ERROR_MESSAGE, 'Failed to fetch datasets');
         } finally {
             setIsLoading(false);
         }
-    };
-    
+    }, [enqueueToast]);
+
     useEffect(() => {
         fetchDatasets();
-    }, []);
+    }, [fetchDatasets]);
 
     const handleFileUpload = async (e) => {
         const file = e.target.files[0];
@@ -175,12 +195,12 @@ const DataHubConfigurator = ({ onSelectDataset }) => {
                 body: formData,
             });
             if (!response.ok) {
-                 throw new Error('Upload failed');
+                throw new Error('Upload failed');
             }
             // Refresh dataset list after successful upload
             fetchDatasets();
         } catch (error) {
-             handleApiError(error, DEFAULT_ERROR_MESSAGE, 'Failed to upload dataset file');
+            handleApiError(enqueueToast, error, DEFAULT_ERROR_MESSAGE, 'Failed to upload dataset file');
         }
     };
 
@@ -235,6 +255,7 @@ const DataHubConfigurator = ({ onSelectDataset }) => {
 };
 
 const LoadWorkflowModal = ({ onLoadWorkflow, closeModal, onCreateNewWorkflow }) => {
+    const enqueueToast = useToast();
     const [workflows, setWorkflows] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
 
@@ -246,30 +267,13 @@ const LoadWorkflowModal = ({ onLoadWorkflow, closeModal, onCreateNewWorkflow }) 
             const data = await response.json();
             setWorkflows(data);
         } catch (error) {
-            console.error(error);
-            alert(error.message);
+            handleApiError(enqueueToast, error, DEFAULT_ERROR_MESSAGE, 'Failed to fetch workflows');
         } finally {
             setIsLoading(false);
         }
-    }, []);
+    }, [enqueueToast]);
 
     useEffect(() => {
-codex/add-empty-state-handling-for-various-components
-
-        const fetchWorkflows = async () => {
-            try {
-                setIsLoading(true);
-                const response = await fetch('/api/v1/workflows');
-                if (!response.ok) throw new Error('Failed to fetch workflows');
-                const data = await response.json();
-                setWorkflows(data);
-            } catch (error) {
-                handleApiError(error, DEFAULT_ERROR_MESSAGE, 'Failed to fetch workflows');
-            } finally {
-                setIsLoading(false);
-            }
-        };
-main
         fetchWorkflows();
     }, [fetchWorkflows]);
 
@@ -480,8 +484,36 @@ export const App = () => {
     const [connectionPreview, setConnectionPreview] = useState(null);
     const [modalState, setModalState] = useState({ isOpen: false, type: null, nodeId: null });
     const [lastRunId, setLastRunId] = useState(null);
-    
+    const [toasts, setToasts] = useState([]);
+
     const canvasRef = useRef(null);
+    const toastTimersRef = useRef(new Map());
+
+    const dismissToast = useCallback((id) => {
+        setToasts(prev => prev.filter(toast => toast.id !== id));
+        const timeoutId = toastTimersRef.current.get(id);
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+            toastTimersRef.current.delete(id);
+        }
+    }, []);
+
+    const enqueueToast = useCallback(({ tone = 'success', title, description }) => {
+        const id = crypto.randomUUID();
+        setToasts(prev => [...prev, { id, tone, title, description }]);
+        const timeoutId = setTimeout(() => {
+            setToasts(prev => prev.filter(toast => toast.id !== id));
+            toastTimersRef.current.delete(id);
+        }, TOAST_DURATION);
+        toastTimersRef.current.set(id, timeoutId);
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            toastTimersRef.current.forEach(clearTimeout);
+            toastTimersRef.current.clear();
+        };
+    }, []);
 
     const handleDragStart = (e, nodeType) => {
         e.dataTransfer.setData('application/reactflow', nodeType);
@@ -641,7 +673,11 @@ export const App = () => {
     const handleSaveWorkflow = async () => {
         const name = prompt("Enter a name for your workflow:");
         if (!name || name.trim() === '') {
-            alert("Workflow name cannot be empty.");
+            enqueueToast({
+                tone: 'error',
+                title: 'Name required',
+                description: 'Workflow name cannot be empty.',
+            });
             return;
         }
 
@@ -670,9 +706,13 @@ export const App = () => {
                 const error = await response.json();
                 throw new Error(error.detail || 'Failed to save workflow.');
             }
-            alert('Workflow saved successfully!');
+            enqueueToast({
+                tone: 'success',
+                title: 'All set!',
+                description: 'Workflow saved successfully.',
+            });
         } catch (error) {
-            handleApiError(error, DEFAULT_ERROR_MESSAGE, 'Failed to save workflow');
+            handleApiError(enqueueToast, error, DEFAULT_ERROR_MESSAGE, 'Failed to save workflow');
         }
     };
 
@@ -701,7 +741,7 @@ export const App = () => {
                 throw new Error('Invalid workflow data received from server.');
             }
         } catch (error) {
-            handleApiError(error, DEFAULT_ERROR_MESSAGE, 'Failed to load workflow');
+            handleApiError(enqueueToast, error, DEFAULT_ERROR_MESSAGE, 'Failed to load workflow');
         }
     };
 
@@ -748,7 +788,7 @@ export const App = () => {
             }
 
         } catch (error) {
-            handleApiError(error, DEFAULT_ERROR_MESSAGE, 'Failed to run workflow');
+            handleApiError(enqueueToast, error, DEFAULT_ERROR_MESSAGE, 'Failed to run workflow');
             // Revert status to idle on failure
             setNodes(prev => prev.map(n => ({...n, status: 'idle'})));
             setLastRunId(null);
@@ -776,31 +816,32 @@ export const App = () => {
 
 
     return (
-        <>
-            <header className="app-header">
-                <h1>Visual Workflow Builder</h1>
-            </header>
-            <main className="main-container">
-                <aside className="sidebar">
-                    <h2>Toolbox</h2>
-                    <div className="sidebar-items-container">
-                        {TOOLBOX_MODULES.map(module => (
-                            <SidebarItem key={module.type} module={module} onDragStart={handleDragStart} />
-                        ))}
-                    </div>
-                </aside>
-                <section
-                    className="canvas-area"
-                    ref={canvasRef}
-                    onDragOver={handleDragOver}
-                    onDrop={handleDrop}
-                >
-                    <Toolbar onRun={runWorkflow} onSave={handleSaveWorkflow} onLoad={() => openModal('load_workflow')} onClear={clearCanvas} />
-                    {lastRunId && (
-                        <div className="run-status">Last run ID: {lastRunId}</div>
-                    )}
-                    <svg className="edge-layer">
-                        {edges.map(edge => {
+        <ToastContext.Provider value={enqueueToast}>
+            <>
+                <header className="app-header">
+                    <h1>Visual Workflow Builder</h1>
+                </header>
+                <main className="main-container">
+                    <aside className="sidebar">
+                        <h2>Toolbox</h2>
+                        <div className="sidebar-items-container">
+                            {TOOLBOX_MODULES.map(module => (
+                                <SidebarItem key={module.type} module={module} onDragStart={handleDragStart} />
+                            ))}
+                        </div>
+                    </aside>
+                    <section
+                        className="canvas-area"
+                        ref={canvasRef}
+                        onDragOver={handleDragOver}
+                        onDrop={handleDrop}
+                    >
+                        <Toolbar onRun={runWorkflow} onSave={handleSaveWorkflow} onLoad={() => openModal('load_workflow')} onClear={clearCanvas} />
+                        {lastRunId && (
+                            <div className="run-status">Last run ID: {lastRunId}</div>
+                        )}
+                        <svg className="edge-layer">
+                            {edges.map(edge => {
                            const fromNode = nodes.find(n => n.id === edge.fromNode);
                            const toNode = nodes.find(n => n.id === edge.toNode);
                            if (!fromNode || !toNode) return null;
@@ -851,12 +892,14 @@ export const App = () => {
                         const module = moduleMap.get(node.type);
                         return module ? <Node key={node.id} node={node} module={module} onMouseDown={handleNodeMouseDown} onPortMouseDown={handlePortMouseDown} onNodeDataChange={handleNodeDataChange} onConfigureNode={handleConfigureNode} /> : null;
                     })}
-                </section>
-            </main>
-             <Modal isOpen={modalState.isOpen} onClose={closeModal} title={MODAL_TITLES[modalState.type] || 'Configuration'}>
-                {renderModalContent()}
-            </Modal>
-        </>
+                    </section>
+                </main>
+                 <Modal isOpen={modalState.isOpen} onClose={closeModal} title={MODAL_TITLES[modalState.type] || 'Configuration'}>
+                    {renderModalContent()}
+                </Modal>
+                <ToastViewport toasts={toasts} onDismiss={dismissToast} />
+            </>
+        </ToastContext.Provider>
     );
 };
 


### PR DESCRIPTION
## Summary
- add a reusable toast context and viewport to replace blocking alerts with accessible notifications
- update modal configurators and workflow flows to enqueue success and error toasts when operations succeed or fail
- style the toast queue to mirror the existing empty-state tone and add supporting empty-state styles

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8a3a846d4832dbe8918adb55955cf