### PR TITLE
Fix backend setup list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ This repository now contains a minimal FastAPI backend with a React/Vite front-e
    ```
 
 3. Run the API server:
-
-2. Run the API server:
- main
    ```bash
    uvicorn main:app --host 0.0.0.0 --port 8000 --reload
    ```


### PR DESCRIPTION
## Summary
- remove the duplicated backend setup list entry and stray text in the README
- ensure the backend setup ordered list counts sequentially around the uvicorn command

## Testing
- python - <<'PY' ...


------
https://chatgpt.com/codex/tasks/task_e_68d8a9fe8edc832d9dc8e54e4bedb66d