### PR TITLE
docs: tidy testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,9 @@ curl -sS -X POST http://localhost:8000/api/v1/workflow/run \
 When you are finished, you can remove the temporary files with `rm -r smoke-tests`.
 
 ## Testing
-codex/set-up-testing-with-vitest-and-testing-library
+
+The project ships with both frontend and backend test suites so you can validate changes quickly.
+
 The frontend includes Vitest suites that cover critical workflow interactions such as uploading datasets, saving/loading workflows, and executing a run. To install dependencies and run the tests locally:
 
 ```bash
@@ -331,4 +333,3 @@ pytest
 ```
 
 The tests spin up the FastAPI application with in-memory clients so they can run without external services.
-main


### PR DESCRIPTION
## Summary
- remove placeholder content from the Testing section of the README
- add a brief overview sentence to introduce the frontend and backend test suites

## Testing
- python - <<'PY'
from pathlib import Path
import html
text = Path('README.md').read_text()
section = text.split('## Testing',1)[1]
if '##' in section:
    section = section.split('##',1)[0]
lines = section.strip().splitlines()
html_lines = []
i = 0
while i < len(lines):
    line = lines[i]
    if line.startswith('```'):
        lang = line.strip('`').strip()
        code = []
        i += 1
        while i < len(lines) and not lines[i].startswith('```'):
            code.append(lines[i])
            i += 1
        html_lines.append(f'<pre><code class="{html.escape(lang)}">\n{html.escape("\n".join(code))}\n</code></pre>')
        i += 1
        continue
    if line.strip() == '':
        html_lines.append('')
    else:
        html_lines.append(f'<p>{html.escape(line)}</p>')
    i += 1
print('\n'.join(html_lines))
PY

------
https://chatgpt.com/codex/tasks/task_e_68d8aa001cfc832d809ff3e2e16ad6c9