### PR TITLE
Add advanced model lifecycle modules to the workflow builder

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -37,13 +37,29 @@ const ToastViewport = ({ toasts, onDismiss }) => (
     </div>
 );
 
-const handleApiError = (enqueueToast, error, fallbackMessage = DEFAULT_ERROR_MESSAGE, context = 'API request failed') => {
-    console.error(context, error);
-    enqueueToast({
-        tone: 'error',
-        title: 'We hit a snag',
-        description: fallbackMessage,
-    });
+const handleApiError = (arg1, arg2 = DEFAULT_ERROR_MESSAGE, arg3 = DEFAULT_ERROR_MESSAGE, arg4 = 'API request failed') => {
+    if (typeof arg1 === 'function') {
+        const enqueueToast = arg1;
+        const error = arg2;
+        const fallbackMessage = arg3 ?? DEFAULT_ERROR_MESSAGE;
+        const context = arg4 ?? 'API request failed';
+        console.error(context, error);
+        enqueueToast({
+            tone: 'error',
+            title: 'We hit a snag',
+            description: fallbackMessage,
+        });
+        return;
+    }
+
+    const errorInfo = arg1 || {};
+    const context = arg2 || 'API request failed';
+    const message = errorInfo.message || DEFAULT_ERROR_MESSAGE;
+    const code = errorInfo.code;
+    const displayMessage = code ? `${message} (Code: ${code})` : message;
+    console.error(context, { message: displayMessage, code });
+    alert(displayMessage);
+};
 
 const extractErrorInfoFromPayload = (payload, fallbackMessage = DEFAULT_ERROR_MESSAGE) => {
     const messageCandidate = payload?.error?.message;
@@ -74,14 +90,6 @@ const createErrorInfo = (error, fallbackMessage = DEFAULT_ERROR_MESSAGE) => {
     return { message: fallbackMessage };
 };
 
-const handleApiError = (errorInfo, context = 'API request failed') => {
-    const { message = DEFAULT_ERROR_MESSAGE, code } = errorInfo || {};
-    const displayMessage = code ? `${message} (Code: ${code})` : message;
-    console.error(context, { message: displayMessage, code });
-    alert(displayMessage);
-main
-};
-
 // --- ICONS ---
 const Icons = {
     Architecture: () => <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 21v-1.5a2.25 2.25 0 0 1 2.25-2.25h12a2.25 2.25 0 0 1 2.25 2.25V21m-15-9.75v-1.5a2.25 2.25 0 0 1 2.25-2.25h12a2.25 2.25 0 0 1 2.25 2.25v1.5m-15-9.75V3.75a2.25 2.25 0 0 1 2.25-2.25h12a2.25 2.25 0 0 1 2.25 2.25v1.5" /><path strokeLinecap="round" strokeLinejoin="round" d="M3 12h18M3 17.25h18M3 6.75h18" /></svg>,
@@ -91,6 +99,43 @@ const Icons = {
     Coordinate: () => <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" /></svg>,
     Solution: () => <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z" /></svg>,
     Resource: () => <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6" /></svg>,
+    DatasetBuild: () => (
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 6.75h15m-15 10.5h15M6 6.75V5.25A1.5 1.5 0 0 1 7.5 3.75h9A1.5 1.5 0 0 1 18 5.25v1.5m0 0v10.5a1.5 1.5 0 0 1-1.5 1.5h-9a1.5 1.5 0 0 1-1.5-1.5V6.75m3 3h6m-6 4.5h3" />
+        </svg>
+    ),
+    Tokenize: () => (
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 4.5h15v15h-15z" />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 4.5v15M15 4.5v15M4.5 9h15M4.5 15h15" />
+        </svg>
+    ),
+    Train: () => (
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 21h12M6 21l1.5-4.5m9 4.5L15 16.5M7.5 16.5h9M9 3h6l3 9H6z" />
+        </svg>
+    ),
+    Merge: () => (
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 7.5 12 3l6 4.5M6 16.5l6 4.5 6-4.5M6 7.5v9m12-9v9M12 3v18" />
+        </svg>
+    ),
+    Quantize: () => (
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 6.75h15m-15 10.5h15M6.75 6.75V4.5a2.25 2.25 0 0 1 2.25-2.25h6a2.25 2.25 0 0 1 2.25 2.25v2.25m0 0v10.5a2.25 2.25 0 0 1-2.25 2.25h-6a2.25 2.25 0 0 1-2.25-2.25V6.75" />
+            <path strokeLinecap="round" strokeLinejoin="round" d="m9 10.5 6 3m0-3-6 3" />
+        </svg>
+    ),
+    Eval: () => (
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 6h18M6 6v12m12-12v12M9 18l2.25-3 1.5 1.5L15 12l3 6" />
+        </svg>
+    ),
+    Publish: () => (
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v12m0 0 3-3m-3 3-3-3M4.5 15a7.5 7.5 0 0 0 15 0V9a7.5 7.5 0 0 0-15 0z" />
+        </svg>
+    ),
     Save: () => <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M9 3.75H6.75A2.25 2.25 0 0 0 4.5 6v12a2.25 2.25 0 0 0 2.25 2.25h10.5A2.25 2.25 0 0 0 19.5 18V9.75l-4.5-4.5H9Z" /><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 3.75v4.5a.75.75 0 0 1-.75.75h-4.5a.75.75 0 0 1-.75-.75v-4.5" /></svg>,
     Load: () => <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9.75h16.5v10.5a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5V9.75Z" /><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9.75V4.5a1.5 1.5 0 0 1 1.5-1.5h4.5l2.25 2.25H18.75a1.5 1.5 0 0 1 1.5 1.5v3" /></svg>,
     Trash: () => <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.134-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.067-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" /></svg>,
@@ -102,12 +147,212 @@ const Icons = {
 const TOOLBOX_MODULES = [
   { type: 'image_input', name: 'Image Input', icon: Icons.Input, inputs: [], outputs: [{ id: 'out', name: 'Image' }] },
   { type: 'text_input', name: 'Text Input', icon: Icons.Architecture, inputs: [], outputs: [{ id: 'out', name: 'Text' }] },
-  { type: 'image_classifier', name: 'Image Classifier', icon: Icons.Classify, inputs: [{ id: 'image', name: 'Image' }, { id: 'model', name: 'Model' }], outputs: [{ id: 'out', name: 'Classification' }] },
-  { type: 'decision_logic', name: 'Decision Logic', icon: Icons.Coordinate, inputs: [{ id: 'in', name: 'Data' }], outputs: [{ id: 'true', name: 'If True' }, { id: 'false', name: 'If False' }] },
-  { type: 'generate_report', name: 'Generate Report (Gemini)', icon: Icons.Solution, inputs: [{ id: 'in', name: 'Data' }], outputs: [{ id: 'out', name: 'Report' }] },
-  { type: 'data_hub', name: 'Data Hub', icon: Icons.Resource, inputs: [], outputs: [{ id: 'out', name: 'Dataset' }] },
-  { type: 'model_hub', name: 'Model Hub', icon: Icons.Inference, inputs: [], outputs: [{ id: 'out', name: 'Model' }] },
+  {
+    type: 'data_hub',
+    name: 'Data Hub',
+    icon: Icons.Resource,
+    inputs: [],
+    outputs: [{ id: 'out', name: 'Dataset' }],
+  },
+  {
+    type: 'dataset_build',
+    name: 'Dataset Build',
+    icon: Icons.DatasetBuild,
+    inputs: [{ id: 'dataset', name: 'Raw Dataset' }],
+    outputs: [{ id: 'preparedDataset', name: 'Prepared Dataset' }],
+  },
+  {
+    type: 'tokenize',
+    name: 'Tokenize Dataset',
+    icon: Icons.Tokenize,
+    inputs: [{ id: 'dataset', name: 'Prepared Dataset' }],
+    outputs: [{ id: 'tokenizedDataset', name: 'Tokenized Dataset' }],
+  },
+  {
+    type: 'model_hub',
+    name: 'Model Hub',
+    icon: Icons.Inference,
+    inputs: [],
+    outputs: [{ id: 'out', name: 'Model' }],
+  },
+  {
+    type: 'train_sft_lora',
+    name: 'Train LoRA (SFT)',
+    icon: Icons.Train,
+    inputs: [
+      { id: 'model', name: 'Base Model' },
+      { id: 'dataset', name: 'Training Dataset' },
+    ],
+    outputs: [{ id: 'loraWeights', name: 'LoRA Weights' }],
+  },
+  {
+    type: 'merge_lora',
+    name: 'Merge LoRA',
+    icon: Icons.Merge,
+    inputs: [
+      { id: 'baseModel', name: 'Base Model' },
+      { id: 'loraWeights', name: 'LoRA Weights' },
+    ],
+    outputs: [{ id: 'mergedModel', name: 'Merged Model' }],
+  },
+  {
+    type: 'quantize_export',
+    name: 'Quantize & Export',
+    icon: Icons.Quantize,
+    inputs: [{ id: 'model', name: 'Model' }],
+    outputs: [{ id: 'quantizedModel', name: 'Quantized Model' }],
+  },
+  {
+    type: 'eval_lmeval',
+    name: 'Eval (LMEval)',
+    icon: Icons.Eval,
+    inputs: [
+      { id: 'model', name: 'Model' },
+      { id: 'dataset', name: 'Evaluation Dataset' },
+    ],
+    outputs: [{ id: 'evalReport', name: 'Evaluation Report' }],
+  },
+  {
+    type: 'registry_publish',
+    name: 'Registry Publish',
+    icon: Icons.Publish,
+    inputs: [
+      { id: 'model', name: 'Model Artifact' },
+      { id: 'evalReport', name: 'Eval Report' },
+    ],
+    outputs: [{ id: 'out', name: 'Published Record' }],
+  },
+  {
+    type: 'image_classifier',
+    name: 'Image Classifier',
+    icon: Icons.Classify,
+    inputs: [
+      { id: 'image', name: 'Image' },
+      { id: 'model', name: 'Model' },
+    ],
+    outputs: [{ id: 'out', name: 'Classification' }],
+  },
+  {
+    type: 'decision_logic',
+    name: 'Decision Logic',
+    icon: Icons.Coordinate,
+    inputs: [{ id: 'in', name: 'Data' }],
+    outputs: [
+      { id: 'true', name: 'If True' },
+      { id: 'false', name: 'If False' },
+    ],
+  },
+  {
+    type: 'generate_report',
+    name: 'Generate Report (Gemini)',
+    icon: Icons.Solution,
+    inputs: [{ id: 'in', name: 'Data' }],
+    outputs: [{ id: 'out', name: 'Report' }],
+  },
 ];
+
+const CONFIGURABLE_NODE_TYPES = new Set([
+  'model_hub',
+  'data_hub',
+  'dataset_build',
+  'tokenize',
+  'train_sft_lora',
+  'merge_lora',
+  'quantize_export',
+  'eval_lmeval',
+  'registry_publish',
+]);
+
+const NODE_PORT_TYPES = {
+  image_input: {
+    outputs: { out: ['image'] },
+  },
+  text_input: {
+    outputs: { out: ['text'] },
+  },
+  data_hub: {
+    outputs: { out: ['dataset.raw', 'dataset.reference'] },
+  },
+  dataset_build: {
+    inputs: { dataset: ['dataset.raw', 'dataset.reference', 'dataset.prepared'] },
+    outputs: { preparedDataset: ['dataset.prepared'] },
+  },
+  tokenize: {
+    inputs: { dataset: ['dataset.prepared', 'dataset.raw', 'dataset.reference'] },
+    outputs: { tokenizedDataset: ['dataset.tokenized'] },
+  },
+  model_hub: {
+    outputs: { out: ['model.base'] },
+  },
+  train_sft_lora: {
+    inputs: {
+      model: ['model.base', 'model.finetuned'],
+      dataset: ['dataset.tokenized', 'dataset.prepared'],
+    },
+    outputs: { loraWeights: ['model.lora'] },
+  },
+  merge_lora: {
+    inputs: {
+      baseModel: ['model.base', 'model.finetuned'],
+      loraWeights: ['model.lora'],
+    },
+    outputs: { mergedModel: ['model.finetuned'] },
+  },
+  quantize_export: {
+    inputs: { model: ['model.finetuned', 'model.base'] },
+    outputs: { quantizedModel: ['model.quantized'] },
+  },
+  eval_lmeval: {
+    inputs: {
+      model: ['model.finetuned', 'model.quantized', 'model.base'],
+      dataset: ['dataset.eval', 'dataset.tokenized', 'dataset.prepared', 'dataset.raw'],
+    },
+    outputs: { evalReport: ['report.eval'] },
+  },
+  registry_publish: {
+    inputs: {
+      model: ['model.quantized', 'model.finetuned', 'model.base'],
+      evalReport: ['report.eval'],
+    },
+    outputs: { out: ['registry.entry'] },
+  },
+  image_classifier: {
+    inputs: {
+      image: ['image'],
+      model: ['model.base', 'model.finetuned'],
+    },
+    outputs: { out: ['classification'] },
+  },
+  decision_logic: {
+    inputs: { in: ['any'] },
+    outputs: { true: ['any'], false: ['any'] },
+  },
+  generate_report: {
+    inputs: { in: ['any'] },
+    outputs: { out: ['text'] },
+  },
+};
+
+const getPortTypes = (nodeType, portId, direction) => {
+  const config = NODE_PORT_TYPES[nodeType];
+  if (!config) {
+    return ['any'];
+  }
+  const collection = direction === 'output' ? config.outputs : config.inputs;
+  if (!collection) {
+    return ['any'];
+  }
+  return collection[portId] || ['any'];
+};
+
+const portsAreCompatible = (sourceNodeType, sourcePortId, targetNodeType, targetPortId) => {
+  const sourceTypes = getPortTypes(sourceNodeType, sourcePortId, 'output');
+  const targetTypes = getPortTypes(targetNodeType, targetPortId, 'input');
+  if (sourceTypes.includes('any') || targetTypes.includes('any')) {
+    return true;
+  }
+  return sourceTypes.some((type) => targetTypes.includes(type));
+};
 
 const getEdgePath = (startPos, endPos) => {
     const dx = endPos.x - startPos.x;
@@ -348,6 +593,533 @@ main
     );
 };
 
+const useBackendCollection = (endpoint, errorContext) => {
+    const enqueueToast = useToast();
+    const [items, setItems] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    const fetchItems = useCallback(async () => {
+        try {
+            setIsLoading(true);
+            const response = await fetch(endpoint);
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            const payload = await response.json();
+            setItems(payload);
+        } catch (error) {
+            handleApiError(enqueueToast, error, DEFAULT_ERROR_MESSAGE, errorContext);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [enqueueToast, endpoint, errorContext]);
+
+    useEffect(() => {
+        fetchItems();
+    }, [fetchItems]);
+
+    return { items, isLoading, refresh: fetchItems };
+};
+
+const DatasetBuildConfigurator = ({ initialData, onSave }) => {
+    const { items: datasets, isLoading, refresh } = useBackendCollection('/api/v1/datasets', 'Failed to fetch datasets');
+    const [selectedDatasetId, setSelectedDatasetId] = useState(initialData?.datasetId || '');
+    const [recordsProcessed, setRecordsProcessed] = useState(initialData?.recordsProcessed ?? 2048);
+    const [recordsRetained, setRecordsRetained] = useState(initialData?.recordsRetained ?? Math.round((initialData?.recordsProcessed ?? 2048) * 0.9));
+    const [notes, setNotes] = useState(initialData?.notes || '');
+
+    useEffect(() => {
+        if (initialData?.datasetId) {
+            setSelectedDatasetId(initialData.datasetId);
+        }
+    }, [initialData?.datasetId]);
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        const selectedDataset = datasets.find((item) => item.id === selectedDatasetId);
+        onSave({
+            datasetId: selectedDatasetId || initialData?.datasetId || '',
+            datasetName: selectedDataset?.name || initialData?.datasetName,
+            recordsProcessed: Number(recordsProcessed) || undefined,
+            recordsRetained: Number(recordsRetained) || undefined,
+            notes: notes || undefined,
+        });
+    };
+
+    return (
+        <form className="configurator-form" onSubmit={handleSubmit}>
+            <label htmlFor="dataset-build-source">Source dataset</label>
+            <select
+                id="dataset-build-source"
+                value={selectedDatasetId}
+                onChange={(e) => setSelectedDatasetId(e.target.value)}
+                disabled={isLoading || datasets.length === 0}
+            >
+                <option value="">Select dataset</option>
+                {datasets.map((dataset) => (
+                    <option key={dataset.id} value={dataset.id}>
+                        {dataset.name}
+                    </option>
+                ))}
+            </select>
+
+            <label htmlFor="dataset-build-records">Records processed</label>
+            <input
+                id="dataset-build-records"
+                type="number"
+                min="1"
+                value={recordsProcessed}
+                onChange={(e) => setRecordsProcessed(e.target.value)}
+            />
+
+            <label htmlFor="dataset-build-retained">Records retained</label>
+            <input
+                id="dataset-build-retained"
+                type="number"
+                min="1"
+                value={recordsRetained}
+                onChange={(e) => setRecordsRetained(e.target.value)}
+            />
+
+            <label htmlFor="dataset-build-notes">Notes</label>
+            <textarea
+                id="dataset-build-notes"
+                rows={3}
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Describe preprocessing steps..."
+            />
+
+            <div className="form-actions">
+                <button type="button" className="configure-btn" onClick={refresh} disabled={isLoading}>
+                    Refresh datasets
+                </button>
+                <button type="submit" className="select-item-btn">
+                    Save configuration
+                </button>
+            </div>
+        </form>
+    );
+};
+
+const TokenizeConfigurator = ({ initialData, onSave }) => {
+    const { items: datasets, isLoading, refresh } = useBackendCollection('/api/v1/datasets', 'Failed to fetch datasets');
+    const [selectedDatasetId, setSelectedDatasetId] = useState(initialData?.datasetId || '');
+    const [tokenizer, setTokenizer] = useState(initialData?.tokenizer || 'sentencepiece');
+    const [batches, setBatches] = useState(initialData?.batches ?? 8);
+    const [tokensPerBatch, setTokensPerBatch] = useState(initialData?.tokensPerBatch ?? 32768);
+
+    useEffect(() => {
+        if (initialData?.datasetId) {
+            setSelectedDatasetId(initialData.datasetId);
+        }
+    }, [initialData?.datasetId]);
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        const selectedDataset = datasets.find((item) => item.id === selectedDatasetId);
+        onSave({
+            datasetId: selectedDatasetId || initialData?.datasetId || '',
+            datasetName: selectedDataset?.name || initialData?.datasetName,
+            tokenizer,
+            batches: Number(batches) || undefined,
+            tokensPerBatch: Number(tokensPerBatch) || undefined,
+        });
+    };
+
+    return (
+        <form className="configurator-form" onSubmit={handleSubmit}>
+            <label htmlFor="tokenize-dataset">Dataset</label>
+            <select
+                id="tokenize-dataset"
+                value={selectedDatasetId}
+                onChange={(e) => setSelectedDatasetId(e.target.value)}
+                disabled={isLoading || datasets.length === 0}
+            >
+                <option value="">Select dataset</option>
+                {datasets.map((dataset) => (
+                    <option key={dataset.id} value={dataset.id}>
+                        {dataset.name}
+                    </option>
+                ))}
+            </select>
+
+            <label htmlFor="tokenizer-name">Tokenizer</label>
+            <input
+                id="tokenizer-name"
+                type="text"
+                value={tokenizer}
+                onChange={(e) => setTokenizer(e.target.value)}
+            />
+
+            <label htmlFor="tokenize-batches">Batches</label>
+            <input
+                id="tokenize-batches"
+                type="number"
+                min="1"
+                value={batches}
+                onChange={(e) => setBatches(e.target.value)}
+            />
+
+            <label htmlFor="tokenize-tokens-per-batch">Tokens per batch</label>
+            <input
+                id="tokenize-tokens-per-batch"
+                type="number"
+                min="1"
+                value={tokensPerBatch}
+                onChange={(e) => setTokensPerBatch(e.target.value)}
+            />
+
+            <div className="form-actions">
+                <button type="button" className="configure-btn" onClick={refresh} disabled={isLoading}>
+                    Refresh datasets
+                </button>
+                <button type="submit" className="select-item-btn">
+                    Save configuration
+                </button>
+            </div>
+        </form>
+    );
+};
+
+const TrainLoraConfigurator = ({ initialData, onSave }) => {
+    const { items: models, isLoading: loadingModels, refresh: refreshModels } = useBackendCollection('/api/v1/models', 'Failed to fetch models');
+    const { items: datasets, isLoading: loadingDatasets, refresh: refreshDatasets } = useBackendCollection('/api/v1/datasets', 'Failed to fetch datasets');
+    const [modelId, setModelId] = useState(initialData?.modelId || '');
+    const [datasetId, setDatasetId] = useState(initialData?.datasetId || '');
+    const [epochs, setEpochs] = useState(initialData?.epochs ?? 1);
+    const [learningRate, setLearningRate] = useState(initialData?.learningRate ?? 1e-4);
+    const [rank, setRank] = useState(initialData?.rank ?? 16);
+    const [adapterName, setAdapterName] = useState(initialData?.adapterName || 'sft-lora');
+
+    useEffect(() => {
+        if (initialData?.modelId) {
+            setModelId(initialData.modelId);
+        }
+        if (initialData?.datasetId) {
+            setDatasetId(initialData.datasetId);
+        }
+    }, [initialData?.modelId, initialData?.datasetId]);
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        const selectedModel = models.find((item) => item.id === modelId);
+        const selectedDataset = datasets.find((item) => item.id === datasetId);
+        onSave({
+            modelId: modelId || initialData?.modelId || '',
+            modelName: selectedModel?.name || initialData?.modelName,
+            datasetId: datasetId || initialData?.datasetId || '',
+            datasetName: selectedDataset?.name || initialData?.datasetName,
+            epochs: Number(epochs) || undefined,
+            learningRate: Number(learningRate) || undefined,
+            rank: Number(rank) || undefined,
+            adapterName: adapterName || undefined,
+        });
+    };
+
+    return (
+        <form className="configurator-form" onSubmit={handleSubmit}>
+            <label htmlFor="train-model">Base model</label>
+            <select
+                id="train-model"
+                value={modelId}
+                onChange={(e) => setModelId(e.target.value)}
+                disabled={loadingModels || models.length === 0}
+            >
+                <option value="">Select model</option>
+                {models.map((model) => (
+                    <option key={model.id} value={model.id}>
+                        {model.name}
+                    </option>
+                ))}
+            </select>
+
+            <label htmlFor="train-dataset">Training dataset</label>
+            <select
+                id="train-dataset"
+                value={datasetId}
+                onChange={(e) => setDatasetId(e.target.value)}
+                disabled={loadingDatasets || datasets.length === 0}
+            >
+                <option value="">Select dataset</option>
+                {datasets.map((dataset) => (
+                    <option key={dataset.id} value={dataset.id}>
+                        {dataset.name}
+                    </option>
+                ))}
+            </select>
+
+            <label htmlFor="train-epochs">Epochs</label>
+            <input
+                id="train-epochs"
+                type="number"
+                min="1"
+                value={epochs}
+                onChange={(e) => setEpochs(e.target.value)}
+            />
+
+            <label htmlFor="train-learning-rate">Learning rate</label>
+            <input
+                id="train-learning-rate"
+                type="number"
+                step="0.00001"
+                value={learningRate}
+                onChange={(e) => setLearningRate(e.target.value)}
+            />
+
+            <label htmlFor="train-rank">LoRA rank</label>
+            <input
+                id="train-rank"
+                type="number"
+                min="1"
+                value={rank}
+                onChange={(e) => setRank(e.target.value)}
+            />
+
+            <label htmlFor="train-adapter-name">Adapter name</label>
+            <input
+                id="train-adapter-name"
+                type="text"
+                value={adapterName}
+                onChange={(e) => setAdapterName(e.target.value)}
+            />
+
+            <div className="form-actions">
+                <button type="button" className="configure-btn" onClick={refreshModels} disabled={loadingModels}>
+                    Refresh models
+                </button>
+                <button type="button" className="configure-btn" onClick={refreshDatasets} disabled={loadingDatasets}>
+                    Refresh datasets
+                </button>
+                <button type="submit" className="select-item-btn">
+                    Save configuration
+                </button>
+            </div>
+        </form>
+    );
+};
+
+const MergeLoraConfigurator = ({ initialData, onSave }) => {
+    const [strategy, setStrategy] = useState(initialData?.strategy || 'Weighted Sum');
+    const [alpha, setAlpha] = useState(initialData?.alpha ?? 0.5);
+    const [outputName, setOutputName] = useState(initialData?.outputName || 'merged-model.safetensors');
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        onSave({
+            strategy,
+            alpha: Number(alpha) || undefined,
+            outputName,
+        });
+    };
+
+    return (
+        <form className="configurator-form" onSubmit={handleSubmit}>
+            <label htmlFor="merge-strategy">Merge strategy</label>
+            <select id="merge-strategy" value={strategy} onChange={(e) => setStrategy(e.target.value)}>
+                <option value="Weighted Sum">Weighted Sum</option>
+                <option value="Layerwise">Layerwise</option>
+                <option value="Residual">Residual</option>
+            </select>
+
+            <label htmlFor="merge-alpha">Alpha</label>
+            <input
+                id="merge-alpha"
+                type="number"
+                step="0.1"
+                min="0"
+                max="1"
+                value={alpha}
+                onChange={(e) => setAlpha(e.target.value)}
+            />
+
+            <label htmlFor="merge-output">Output filename</label>
+            <input
+                id="merge-output"
+                type="text"
+                value={outputName}
+                onChange={(e) => setOutputName(e.target.value)}
+            />
+
+            <div className="form-actions">
+                <button type="submit" className="select-item-btn">
+                    Save configuration
+                </button>
+            </div>
+        </form>
+    );
+};
+
+const QuantizeConfigurator = ({ initialData, onSave }) => {
+    const [bits, setBits] = useState(initialData?.bits ?? 4);
+    const [scheme, setScheme] = useState(initialData?.scheme || 'nf4');
+    const [calibrationSamples, setCalibrationSamples] = useState(initialData?.calibrationSamples ?? 128);
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        onSave({
+            bits: Number(bits) || undefined,
+            scheme,
+            calibrationSamples: Number(calibrationSamples) || undefined,
+        });
+    };
+
+    return (
+        <form className="configurator-form" onSubmit={handleSubmit}>
+            <label htmlFor="quantize-bits">Bits</label>
+            <input
+                id="quantize-bits"
+                type="number"
+                min="2"
+                max="16"
+                value={bits}
+                onChange={(e) => setBits(e.target.value)}
+            />
+
+            <label htmlFor="quantize-scheme">Scheme</label>
+            <select id="quantize-scheme" value={scheme} onChange={(e) => setScheme(e.target.value)}>
+                <option value="nf4">NF4</option>
+                <option value="fp8">FP8</option>
+                <option value="int8">INT8</option>
+            </select>
+
+            <label htmlFor="quantize-calibration">Calibration samples</label>
+            <input
+                id="quantize-calibration"
+                type="number"
+                min="1"
+                value={calibrationSamples}
+                onChange={(e) => setCalibrationSamples(e.target.value)}
+            />
+
+            <div className="form-actions">
+                <button type="submit" className="select-item-btn">
+                    Save configuration
+                </button>
+            </div>
+        </form>
+    );
+};
+
+const BENCHMARK_OPTIONS = ['mmlu', 'gsm8k', 'arc-c', 'truthfulqa'];
+
+const EvalConfigurator = ({ initialData, onSave }) => {
+    const { items: datasets, isLoading, refresh } = useBackendCollection('/api/v1/datasets', 'Failed to fetch datasets');
+    const [datasetId, setDatasetId] = useState(initialData?.datasetId || '');
+    const [benchmark, setBenchmark] = useState(initialData?.benchmark || BENCHMARK_OPTIONS[0]);
+    const [shots, setShots] = useState(initialData?.shots ?? 0);
+
+    useEffect(() => {
+        if (initialData?.datasetId) {
+            setDatasetId(initialData.datasetId);
+        }
+    }, [initialData?.datasetId]);
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        const selectedDataset = datasets.find((item) => item.id === datasetId);
+        onSave({
+            datasetId: datasetId || initialData?.datasetId || '',
+            datasetName: selectedDataset?.name || initialData?.datasetName,
+            benchmark,
+            shots: Number(shots) || 0,
+        });
+    };
+
+    return (
+        <form className="configurator-form" onSubmit={handleSubmit}>
+            <label htmlFor="eval-dataset">Evaluation dataset</label>
+            <select
+                id="eval-dataset"
+                value={datasetId}
+                onChange={(e) => setDatasetId(e.target.value)}
+                disabled={isLoading || datasets.length === 0}
+            >
+                <option value="">Select dataset</option>
+                {datasets.map((dataset) => (
+                    <option key={dataset.id} value={dataset.id}>
+                        {dataset.name}
+                    </option>
+                ))}
+            </select>
+
+            <label htmlFor="eval-benchmark">Benchmark</label>
+            <select id="eval-benchmark" value={benchmark} onChange={(e) => setBenchmark(e.target.value)}>
+                {BENCHMARK_OPTIONS.map((option) => (
+                    <option key={option} value={option}>
+                        {option.toUpperCase()}
+                    </option>
+                ))}
+            </select>
+
+            <label htmlFor="eval-shots">Few-shot examples</label>
+            <input
+                id="eval-shots"
+                type="number"
+                min="0"
+                value={shots}
+                onChange={(e) => setShots(e.target.value)}
+            />
+
+            <div className="form-actions">
+                <button type="button" className="configure-btn" onClick={refresh} disabled={isLoading}>
+                    Refresh datasets
+                </button>
+                <button type="submit" className="select-item-btn">
+                    Save configuration
+                </button>
+            </div>
+        </form>
+    );
+};
+
+const RegistryPublishConfigurator = ({ initialData, onSave }) => {
+    const [target, setTarget] = useState(initialData?.target || 'Model Registry');
+    const [visibility, setVisibility] = useState(initialData?.visibility || 'private');
+    const [versionTag, setVersionTag] = useState(initialData?.versionTag || 'v1');
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        onSave({
+            target,
+            visibility,
+            versionTag,
+        });
+    };
+
+    return (
+        <form className="configurator-form" onSubmit={handleSubmit}>
+            <label htmlFor="publish-target">Target registry</label>
+            <select id="publish-target" value={target} onChange={(e) => setTarget(e.target.value)}>
+                <option value="Model Registry">Model Registry</option>
+                <option value="Vertex AI">Vertex AI</option>
+                <option value="Hugging Face">Hugging Face</option>
+            </select>
+
+            <label htmlFor="publish-visibility">Visibility</label>
+            <select id="publish-visibility" value={visibility} onChange={(e) => setVisibility(e.target.value)}>
+                <option value="private">Private</option>
+                <option value="internal">Internal</option>
+                <option value="public">Public</option>
+            </select>
+
+            <label htmlFor="publish-version">Version tag</label>
+            <input
+                id="publish-version"
+                type="text"
+                value={versionTag}
+                onChange={(e) => setVersionTag(e.target.value)}
+            />
+
+            <div className="form-actions">
+                <button type="submit" className="select-item-btn">
+                    Save configuration
+                </button>
+            </div>
+        </form>
+    );
+};
+
 const LoadWorkflowModal = ({ onLoadWorkflow, closeModal, onCreateNewWorkflow }) => {
     const enqueueToast = useToast();
     const [workflows, setWorkflows] = useState([]);
@@ -493,8 +1265,8 @@ const NodeBody = ({ type, data, onDataChange, onConfigure }) => {
         case 'generate_report':
             return (
                 <div className="node-content column">
-                    <textarea 
-                        value={data.prompt || ''} 
+                    <textarea
+                        value={data.prompt || ''}
                         onChange={(e) => onDataChange({ ...data, prompt: e.target.value })} 
                         placeholder="Prompt template..."
                         rows={3}
@@ -502,7 +1274,35 @@ const NodeBody = ({ type, data, onDataChange, onConfigure }) => {
                     {data.report && <div className="report-output">{data.report}</div>}
                 </div>
             );
-         case 'model_hub':
+        case 'dataset_build':
+            return (
+                <div className="node-content column">
+                    <div className="hub-display">
+                        <span>Source:</span>
+                        <code>{data.datasetName || data.datasetId || 'Not Selected'}</code>
+                    </div>
+                    <div className="hub-display">
+                        <span>Records:</span>
+                        <code>{data.recordsProcessed ? `${data.recordsProcessed}` : 'Auto'}</code>
+                    </div>
+                    <button className="configure-btn" onClick={onConfigure}>Configure Build</button>
+                </div>
+            );
+        case 'tokenize':
+            return (
+                <div className="node-content column">
+                    <div className="hub-display">
+                        <span>Tokenizer:</span>
+                        <code>{data.tokenizer || 'sentencepiece'}</code>
+                    </div>
+                    <div className="hub-display">
+                        <span>Batches:</span>
+                        <code>{data.batches || 'Auto'}</code>
+                    </div>
+                    <button className="configure-btn" onClick={onConfigure}>Configure Tokenizer</button>
+                </div>
+            );
+        case 'model_hub':
             return (
                 <div className="node-content column">
                     <div className="hub-display">
@@ -520,6 +1320,76 @@ const NodeBody = ({ type, data, onDataChange, onConfigure }) => {
                         <code>{data.datasetName || 'Not Selected'}</code>
                     </div>
                     <button className="configure-btn" onClick={onConfigure}>Configure Dataset</button>
+                </div>
+            );
+        case 'train_sft_lora':
+            return (
+                <div className="node-content column">
+                    <div className="hub-display">
+                        <span>Model:</span>
+                        <code>{data.modelName || data.modelId || 'Not Selected'}</code>
+                    </div>
+                    <div className="hub-display">
+                        <span>Epochs:</span>
+                        <code>{data.epochs || 1}</code>
+                    </div>
+                    <button className="configure-btn" onClick={onConfigure}>Configure Training</button>
+                </div>
+            );
+        case 'merge_lora':
+            return (
+                <div className="node-content column">
+                    <div className="hub-display">
+                        <span>Strategy:</span>
+                        <code>{data.strategy || 'Weighted Sum'}</code>
+                    </div>
+                    <div className="hub-display">
+                        <span>Output:</span>
+                        <code>{data.outputName || 'merged-model.safetensors'}</code>
+                    </div>
+                    <button className="configure-btn" onClick={onConfigure}>Configure Merge</button>
+                </div>
+            );
+        case 'quantize_export':
+            return (
+                <div className="node-content column">
+                    <div className="hub-display">
+                        <span>Bits:</span>
+                        <code>{data.bits || 4}</code>
+                    </div>
+                    <div className="hub-display">
+                        <span>Scheme:</span>
+                        <code>{data.scheme || 'nf4'}</code>
+                    </div>
+                    <button className="configure-btn" onClick={onConfigure}>Configure Quantization</button>
+                </div>
+            );
+        case 'eval_lmeval':
+            return (
+                <div className="node-content column">
+                    <div className="hub-display">
+                        <span>Benchmark:</span>
+                        <code>{data.benchmark || 'mmlu'}</code>
+                    </div>
+                    <div className="hub-display">
+                        <span>Dataset:</span>
+                        <code>{data.datasetName || data.datasetId || 'Not Selected'}</code>
+                    </div>
+                    <button className="configure-btn" onClick={onConfigure}>Configure Evaluation</button>
+                </div>
+            );
+        case 'registry_publish':
+            return (
+                <div className="node-content column">
+                    <div className="hub-display">
+                        <span>Target:</span>
+                        <code>{data.target || 'Model Registry'}</code>
+                    </div>
+                    <div className="hub-display">
+                        <span>Visibility:</span>
+                        <code>{data.visibility || 'private'}</code>
+                    </div>
+                    <button className="configure-btn" onClick={onConfigure}>Configure Publish</button>
                 </div>
             );
         default:
@@ -715,21 +1585,40 @@ export const App = () => {
                 const endNodeId = targetEl.dataset.nodeId;
                 const endPortId = targetEl.dataset.portId;
                 const startNodeId = connectionPreview.startNodeId;
-                
-                if (endNodeId !== startNodeId) {
-                    const newEdge = {
-                        id: crypto.randomUUID(),
-                        fromNode: startNodeId,
-                        fromPort: connectionPreview.startPortId,
-                        toNode: endNodeId,
-                        toPort: endPortId,
-                    };
-                    setEdges(prev => [...prev, newEdge]);
+
+                if (endNodeId && endPortId && startNodeId && endNodeId !== startNodeId) {
+                    const fromNode = nodes.find(n => n.id === startNodeId);
+                    const toNode = nodes.find(n => n.id === endNodeId);
+
+                    if (fromNode && toNode) {
+                        if (!portsAreCompatible(fromNode.type, connectionPreview.startPortId, toNode.type, endPortId)) {
+                            enqueueToast({
+                                tone: 'error',
+                                title: 'Invalid connection',
+                                description: 'The selected ports are not compatible.',
+                            });
+                        } else if (edges.some(edge => edge.toNode === endNodeId && edge.toPort === endPortId)) {
+                            enqueueToast({
+                                tone: 'error',
+                                title: 'Input already connected',
+                                description: 'Disconnect the existing edge before connecting a new one.',
+                            });
+                        } else {
+                            const newEdge = {
+                                id: crypto.randomUUID(),
+                                fromNode: startNodeId,
+                                fromPort: connectionPreview.startPortId,
+                                toNode: endNodeId,
+                                toPort: endPortId,
+                            };
+                            setEdges(prev => [...prev, newEdge]);
+                        }
+                    }
                 }
             }
             setConnectionPreview(null);
         }
-    }, [connectionPreview]);
+    }, [connectionPreview, nodes, edges, enqueueToast]);
     
     useEffect(() => {
         window.addEventListener('mousemove', handleMouseMove);
@@ -755,7 +1644,7 @@ export const App = () => {
     };
 
     const handleConfigureNode = (nodeId, type) => {
-        if (type === 'model_hub' || type === 'data_hub') {
+        if (CONFIGURABLE_NODE_TYPES.has(type)) {
             openModal(type, nodeId);
         }
     };
@@ -946,15 +1835,45 @@ main
     const MODAL_TITLES = {
         'model_hub': 'Model Hub',
         'data_hub': 'Data Hub',
+        'dataset_build': 'Dataset Build',
+        'tokenize': 'Tokenize Dataset',
+        'train_sft_lora': 'Train LoRA (SFT)',
+        'merge_lora': 'Merge LoRA',
+        'quantize_export': 'Quantize & Export',
+        'eval_lmeval': 'Eval (LMEval)',
+        'registry_publish': 'Registry Publish',
         'load_workflow': 'Load Workflow'
     };
 
     const renderModalContent = () => {
+        const currentNode = nodes.find(n => n.id === modalState.nodeId);
+        const currentData = currentNode?.data || {};
+        const applyConfiguration = (updates) => {
+            if (!modalState.nodeId) return;
+            const latestNode = nodes.find(n => n.id === modalState.nodeId);
+            const latestData = latestNode?.data || {};
+            handleNodeDataChange(modalState.nodeId, { ...latestData, ...updates });
+            closeModal();
+        };
         switch (modalState.type) {
             case 'model_hub':
                 return <ModelHubConfigurator onSelectModel={handleSelectModel} />;
             case 'data_hub':
                 return <DataHubConfigurator onSelectDataset={handleSelectDataset} />;
+            case 'dataset_build':
+                return <DatasetBuildConfigurator initialData={currentData} onSave={applyConfiguration} />;
+            case 'tokenize':
+                return <TokenizeConfigurator initialData={currentData} onSave={applyConfiguration} />;
+            case 'train_sft_lora':
+                return <TrainLoraConfigurator initialData={currentData} onSave={applyConfiguration} />;
+            case 'merge_lora':
+                return <MergeLoraConfigurator initialData={currentData} onSave={applyConfiguration} />;
+            case 'quantize_export':
+                return <QuantizeConfigurator initialData={currentData} onSave={applyConfiguration} />;
+            case 'eval_lmeval':
+                return <EvalConfigurator initialData={currentData} onSave={applyConfiguration} />;
+            case 'registry_publish':
+                return <RegistryPublishConfigurator initialData={currentData} onSave={applyConfiguration} />;
             case 'load_workflow':
                 return <LoadWorkflowModal onLoadWorkflow={handleLoadWorkflow} closeModal={closeModal} onCreateNewWorkflow={clearCanvas} />;
             default:

--- a/package.json
+++ b/package.json
@@ -6,14 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-codex/create-ci-workflow-with-caching-and-docker-build
     "lint": "tsc --noEmit",
-    "test": "vite build --mode test",
+    "test": "vitest",
     "preview": "vite preview"
-
-    "preview": "vite preview",
-    "test": "vitest"
-main
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/src/__tests__/advanced-modules.test.tsx
+++ b/src/__tests__/advanced-modules.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { vi, describe, test, beforeEach } from 'vitest';
+import { App } from '@/index';
+import { server } from './setup';
+import { addModuleToCanvas } from './test-utils';
+
+const mockCanvasRect = () => {
+  const canvas = document.querySelector('.canvas-area');
+  if (!canvas) {
+    throw new Error('Canvas not found');
+  }
+  vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: 1200,
+    bottom: 800,
+    width: 1200,
+    height: 800,
+    toJSON() {
+      return {};
+    },
+  } as DOMRect);
+};
+
+describe('advanced workflow modules', () => {
+  beforeEach(() => {
+    server.use(
+      http.get('/api/v1/datasets', () =>
+        HttpResponse.json([
+          { id: 'dataset-1', name: 'Demo Dataset', type: 'text' },
+        ])
+      ),
+      http.get('/api/v1/models', () =>
+        HttpResponse.json([
+          { id: 'gemini-1.5-flash', name: 'Gemini 1.5 Flash', description: 'Fast model' },
+        ])
+      )
+    );
+  });
+
+  test('configures dataset build and downstream modules', async () => {
+    render(<App />);
+
+    await addModuleToCanvas('Dataset Build');
+    await addModuleToCanvas('Tokenize Dataset');
+    await addModuleToCanvas('Train LoRA (SFT)');
+    await addModuleToCanvas('Quantize & Export');
+    await addModuleToCanvas('Eval (LMEval)');
+    await addModuleToCanvas('Registry Publish');
+
+    const buildConfigure = await screen.findByRole('button', { name: /configure build/i });
+    await userEvent.click(buildConfigure);
+    const datasetSelect = await screen.findByLabelText(/source dataset/i);
+    await userEvent.selectOptions(datasetSelect, 'dataset-1');
+    const saveButtons = screen.getAllByRole('button', { name: /save configuration/i });
+    await userEvent.click(saveButtons[saveButtons.length - 1]);
+
+    const buildNode = (await screen.findByText('Dataset Build')).closest('.node');
+    if (!buildNode) throw new Error('Dataset Build node not found');
+    await waitFor(() => {
+      expect(within(buildNode).getByText('Demo Dataset')).toBeInTheDocument();
+    });
+
+    const tokenizeConfigure = await screen.findByRole('button', { name: /configure tokenizer/i });
+    await userEvent.click(tokenizeConfigure);
+    const tokenizeDatasetSelect = await screen.findByLabelText(/dataset/i);
+    await userEvent.selectOptions(tokenizeDatasetSelect, 'dataset-1');
+    const tokenizerInput = screen.getByLabelText(/tokenizer/i);
+    await userEvent.clear(tokenizerInput);
+    await userEvent.type(tokenizerInput, 'tiktoken');
+    await userEvent.click(screen.getAllByRole('button', { name: /save configuration/i }).slice(-1)[0]);
+
+    const tokenizeNode = (await screen.findByText('Tokenize Dataset')).closest('.node');
+    if (!tokenizeNode) throw new Error('Tokenize node not found');
+    await waitFor(() => {
+      expect(within(tokenizeNode).getByText('tiktoken')).toBeInTheDocument();
+    });
+
+    const trainConfigure = await screen.findByRole('button', { name: /configure training/i });
+    await userEvent.click(trainConfigure);
+    const baseModelSelect = await screen.findByLabelText(/base model/i);
+    await userEvent.selectOptions(baseModelSelect, 'gemini-1.5-flash');
+    const trainDatasetSelect = screen.getByLabelText(/training dataset/i);
+    await userEvent.selectOptions(trainDatasetSelect, 'dataset-1');
+    const epochsInput = screen.getByLabelText(/epochs/i);
+    await userEvent.clear(epochsInput);
+    await userEvent.type(epochsInput, '3');
+    await userEvent.click(screen.getAllByRole('button', { name: /save configuration/i }).slice(-1)[0]);
+
+    const trainNode = (await screen.findByText('Train LoRA (SFT)')).closest('.node');
+    if (!trainNode) throw new Error('Train node not found');
+    await waitFor(() => {
+      expect(within(trainNode).getByText(/Gemini 1.5 Flash/)).toBeInTheDocument();
+      expect(within(trainNode).getByText('3')).toBeInTheDocument();
+    });
+
+    const quantizeConfigure = await screen.findByRole('button', { name: /configure quantization/i });
+    await userEvent.click(quantizeConfigure);
+    const bitsInput = await screen.findByLabelText(/bits/i);
+    await userEvent.clear(bitsInput);
+    await userEvent.type(bitsInput, '8');
+    await userEvent.click(screen.getAllByRole('button', { name: /save configuration/i }).slice(-1)[0]);
+
+    const quantizeNode = (await screen.findByText('Quantize & Export')).closest('.node');
+    if (!quantizeNode) throw new Error('Quantize node not found');
+    await waitFor(() => {
+      expect(within(quantizeNode).getByText('8')).toBeInTheDocument();
+    });
+
+    const evalConfigure = await screen.findByRole('button', { name: /configure evaluation/i });
+    await userEvent.click(evalConfigure);
+    const evalDatasetSelect = await screen.findByLabelText(/evaluation dataset/i);
+    await userEvent.selectOptions(evalDatasetSelect, 'dataset-1');
+    const benchmarkSelect = screen.getByLabelText(/benchmark/i);
+    await userEvent.selectOptions(benchmarkSelect, 'gsm8k');
+    await userEvent.click(screen.getAllByRole('button', { name: /save configuration/i }).slice(-1)[0]);
+
+    const evalNode = (await screen.findByText('Eval (LMEval)')).closest('.node');
+    if (!evalNode) throw new Error('Eval node not found');
+    await waitFor(() => {
+      expect(within(evalNode).getByText('GSM8K')).toBeInTheDocument();
+    });
+
+    const publishConfigure = await screen.findByRole('button', { name: /configure publish/i });
+    await userEvent.click(publishConfigure);
+    const visibilitySelect = await screen.findByLabelText(/visibility/i);
+    await userEvent.selectOptions(visibilitySelect, 'public');
+    await userEvent.click(screen.getAllByRole('button', { name: /save configuration/i }).slice(-1)[0]);
+
+    const publishNode = (await screen.findByText('Registry Publish')).closest('.node');
+    if (!publishNode) throw new Error('Publish node not found');
+    await waitFor(() => {
+      expect(within(publishNode).getByText('public')).toBeInTheDocument();
+    });
+  });
+
+  test('validates port compatibility and prevents duplicate connections', async () => {
+    render(<App />);
+    await addModuleToCanvas('Text Input');
+    await addModuleToCanvas('Model Hub');
+    await addModuleToCanvas('Data Hub');
+    await addModuleToCanvas('Train LoRA (SFT)');
+
+    mockCanvasRect();
+
+    const textNode = (await screen.findByText('Text Input')).closest('.node');
+    const trainNode = (await screen.findByText('Train LoRA (SFT)')).closest('.node');
+    const modelNode = (await screen.findByText('Model Hub')).closest('.node');
+    const dataNode = (await screen.findByText('Data Hub')).closest('.node');
+    if (!textNode || !trainNode || !modelNode || !dataNode) {
+      throw new Error('Required nodes not found');
+    }
+
+    const textOutput = textNode.querySelector('.output-port[data-port-id="out"]');
+    const trainDatasetInput = trainNode.querySelector('.input-port[data-port-id="dataset"]');
+    if (!textOutput || !trainDatasetInput) {
+      throw new Error('Ports not found for invalid connection test');
+    }
+
+    fireEvent.mouseDown(textOutput, { clientX: 10, clientY: 10 });
+    fireEvent.mouseUp(trainDatasetInput, { clientX: 20, clientY: 20 });
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.edge').length).toBe(0);
+    });
+
+    const modelOutput = modelNode.querySelector('.output-port[data-port-id="out"]');
+    const trainModelInput = trainNode.querySelector('.input-port[data-port-id="model"]');
+    if (!modelOutput || !trainModelInput) {
+      throw new Error('Ports not found for model connection test');
+    }
+
+    fireEvent.mouseDown(modelOutput, { clientX: 30, clientY: 30 });
+    fireEvent.mouseUp(trainModelInput, { clientX: 40, clientY: 40 });
+
+    const dataOutput = dataNode.querySelector('.output-port[data-port-id="out"]');
+    if (!dataOutput) {
+      throw new Error('Data hub output port not found');
+    }
+
+    fireEvent.mouseDown(dataOutput, { clientX: 50, clientY: 50 });
+    fireEvent.mouseUp(trainDatasetInput, { clientX: 60, clientY: 60 });
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.edge').length).toBe(2);
+    });
+
+    fireEvent.mouseDown(dataOutput, { clientX: 70, clientY: 70 });
+    fireEvent.mouseUp(trainDatasetInput, { clientX: 80, clientY: 80 });
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.edge').length).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend the toolbox with dataset build, tokenization, LoRA training/merge, quantization, evaluation, and registry publish nodes with dedicated icons and ports
- add configuration panels that fetch backend datasets/models and capture module parameters while enhancing modal handling and connection validation
- cover the new flow with vitest UI tests and document the npm-based test workflow

## Testing
- npm test *(fails: registry access forbidden in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ab6f407c832d937c96ca6d0228e3