### PR TITLE
Fix dataset listing to use persisted index

### DIFF
--- a/main.py
+++ b/main.py
@@ -1096,11 +1096,7 @@ def delete_model(model_id: str) -> Response:
 def list_datasets() -> List[Dict[str, Any]]:
     """Return metadata for uploaded datasets."""
 
-codex/rewrite-backend-using-fastapi-and-implement-routes-k68a2h
-    return _collect_dataset_metadata()
-
     return _dataset_index()
-main
 
 
 @app.post("/api/v1/datasets/upload")

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -25,7 +25,7 @@ def _load_main_module() -> ModuleType:
     sanitised_lines = []
     for line in source.splitlines():
         stripped = line.strip()
-        if line.startswith("codex/") or stripped == "main":
+        if stripped.startswith("codex/") or stripped == "main":
             continue
         if (
             stripped
@@ -52,15 +52,12 @@ def _load_main_module() -> ModuleType:
         "TrainStartRequest",
         "TrainStatusResponse",
         "TrainAbortRequest",
-codex/add-model-registration-storage-and-apis
         "ModelRegistryEntry",
         "ModelRegistryCreateRequest",
-
         "TrainingJobStartRequest",
         "TrainingJobStartResponse",
         "TrainingJobStatusResponse",
         "TrainingJobAbortRequest",
-main
     ):
         model = getattr(module, model_name, None)
         rebuild = getattr(model, "model_rebuild", None)

--- a/tests/backend/test_datasets.py
+++ b/tests/backend/test_datasets.py
@@ -38,8 +38,7 @@ async def test_upload_dataset_persists_metadata(async_client, workflow_main, sto
     datasets = list_response.json()
     assert len(datasets) == 1
     dataset_entry = datasets[0]
-    assert dataset_entry["datasetId"] == dataset_id
-    assert dataset_entry["name"] == "notes.txt"
+    assert dataset_entry == metadata
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
## Summary
- return the persisted dataset index from the /api/v1/datasets handler
- adjust the dataset backend test to assert the stored metadata payload shape
- clean the backend test bootstrap so codemod markers do not break imports

## Testing
- pytest tests/backend/test_datasets.py

------
https://chatgpt.com/codex/tasks/task_e_68d8dc556154832d9087f667dcf21850