### PR TITLE
Simplify dataset listing endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1080,12 +1080,7 @@ def delete_model(model_id: str) -> Response:
 def list_datasets() -> List[Dict[str, Any]]:
     """Return metadata for uploaded datasets."""
 
-codex/update-list_datasets-function-to-return-one-source
-
     return _collect_dataset_metadata()
-
-main
-    return _dataset_index()
 
 
 @app.post("/api/v1/datasets/upload")


### PR DESCRIPTION
## Summary
- remove stray marker lines from `list_datasets`
- ensure the dataset listing endpoint delegates solely to `_collect_dataset_metadata`

## Testing
- uvicorn main:app --reload

------
https://chatgpt.com/codex/tasks/task_e_68d8e4cb776c832db969ae55cd26b26c