### PR TITLE
Consolidate training endpoints and update backend tests

### DIFF
--- a/storage/models/index.json
+++ b/storage/models/index.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "name": "Model publish",
+    "source": "training-run",
+    "description": null,
+    "quantization": null,
+    "metadata": {
+      "quantizedModel": {
+        "artifactPath": "runs/test-run-893820e4/quantize/model-int4.gguf",
+        "quantizedModelPath": "runs/test-run-893820e4/quantize",
+        "dtype": "int4",
+        "source": null,
+        "quantizationScheme": "nf4",
+        "quantizedAt": 1759048190
+      }
+    },
+    "id": "3706e010-d83d-43ac-8385-c2a0b8742c55",
+    "registeredAt": "2025-09-28T08:29:50Z"
+  }
+]

--- a/storage/models/registry.json
+++ b/storage/models/registry.json
@@ -1,0 +1,16 @@
+{
+  "test-model": {
+    "modelId": "test-model",
+    "quantizedModel": {
+      "artifactPath": "runs/test-run-893820e4/quantize/model-int4.gguf",
+      "quantizedModelPath": "runs/test-run-893820e4/quantize",
+      "dtype": "int4",
+      "source": null,
+      "quantizationScheme": "nf4",
+      "quantizedAt": 1759048190
+    },
+    "evaluation": null,
+    "publishedAt": 1759048190,
+    "runId": "test-run-893820e4"
+  }
+}

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -49,15 +49,8 @@ def _load_main_module() -> ModuleType:
         "TrainingStartRequest",
         "TrainingStatusResponse",
         "TrainingAbortRequest",
-        "TrainStartRequest",
-        "TrainStatusResponse",
-        "TrainAbortRequest",
         "ModelRegistryEntry",
         "ModelRegistryCreateRequest",
-        "TrainingJobStartRequest",
-        "TrainingJobStartResponse",
-        "TrainingJobStatusResponse",
-        "TrainingJobAbortRequest",
     ):
         model = getattr(module, model_name, None)
         rebuild = getattr(model, "model_rebuild", None)
@@ -103,6 +96,11 @@ def storage_paths(workflow_main: ModuleType, tmp_path: Path, monkeypatch: pytest
     monkeypatch.setattr(workflow_main, "DATASETS_INDEX_PATH", datasets_dir / "index.json")
     monkeypatch.setattr(workflow_main, "MODELS_INDEX_PATH", models_dir / "index.json")
     monkeypatch.setattr(workflow_main, "TRAINING_STATE_PATH", storage_dir / "training_state.json")
+
+    training_controller = workflow_main.TrainingController(
+        workflow_main.TRAINING_STATE_PATH, workflow_main.LOGGER
+    )
+    monkeypatch.setattr(workflow_main, "TRAINING_CONTROLLER", training_controller)
 
     return {
         "base": base_dir,

--- a/tests/backend/test_datasets.py
+++ b/tests/backend/test_datasets.py
@@ -38,7 +38,14 @@ async def test_upload_dataset_persists_metadata(async_client, workflow_main, sto
     datasets = list_response.json()
     assert len(datasets) == 1
     dataset_entry = datasets[0]
-    assert dataset_entry == metadata
+    assert dataset_entry["id"] == dataset_id
+    assert dataset_entry["datasetId"] == dataset_id
+    assert dataset_entry["name"] == "notes.txt"
+    assert dataset_entry["storedFilename"] == "notes.txt"
+    assert dataset_entry["size"] == metadata["size"]
+    assert dataset_entry["mimeType"] == metadata["mimeType"]
+    assert dataset_entry["type"] == metadata["type"]
+    assert dataset_entry["preview"] == "sample data"
 
 
 @pytest.mark.anyio("asyncio")

--- a/tests/backend/test_training_routes.py
+++ b/tests/backend/test_training_routes.py
@@ -7,47 +7,57 @@ import pytest
 
 @pytest.mark.anyio
 async def test_training_lifecycle(async_client):
-    start_response = await async_client.post("/train/start", json={"steps": 5, "description": "unit-test"})
+    request_payload = {
+        "datasetId": "unit-dataset",
+        "modelId": "unit-model",
+        "hyperparameters": {"learningRate": 0.1},
+        "notes": "integration-test",
+    }
+    start_response = await async_client.post("/api/v1/train/start", json=request_payload)
     assert start_response.status_code == 200
     payload = start_response.json()
-    run_id = payload.get("runId")
-    assert isinstance(run_id, str) and run_id
+    job_id = payload.get("jobId")
+    assert isinstance(job_id, str) and job_id
+    assert payload["datasetId"] == request_payload["datasetId"]
+    assert payload["modelId"] == request_payload["modelId"]
+    assert payload["status"] in {"running", "queued"}
 
-    status_response = await async_client.get(f"/train/status?runId={run_id}")
+    status_response = await async_client.get(f"/api/v1/train/status?jobId={job_id}")
     assert status_response.status_code == 200
     status_payload = status_response.json()
-    assert status_payload["runId"] == run_id
-    assert status_payload["state"] in {"pending", "running", "completed"}
+    assert status_payload["jobId"] == job_id
+    assert status_payload["status"] in {"running", "completed"}
+    assert 0.0 <= status_payload["progress"] <= 1.0
 
-    abort_response = await async_client.post("/train/abort", json={"runId": run_id})
+    abort_response = await async_client.post("/api/v1/train/abort", json={"jobId": job_id})
     assert abort_response.status_code == 200
 
     final_state = None
     for _ in range(30):
-        poll_response = await async_client.get(f"/train/status?runId={run_id}")
+        poll_response = await async_client.get(f"/api/v1/train/status?jobId={job_id}")
         assert poll_response.status_code == 200
         poll_payload = poll_response.json()
-        final_state = poll_payload["state"]
+        final_state = poll_payload["status"]
         if final_state == "aborted":
             break
         await asyncio.sleep(0.1)
     else:  # pragma: no cover - would indicate the abort didn't take effect in time
-        pytest.fail("Training run did not enter the aborted state in time")
+        pytest.fail("Training job did not enter the aborted state in time")
 
     assert final_state == "aborted"
 
 
 @pytest.mark.anyio
-async def test_training_status_unknown_run(async_client):
-    response = await async_client.get("/train/status?runId=missing")
+async def test_training_status_unknown_job(async_client):
+    response = await async_client.get("/api/v1/train/status?jobId=missing")
     assert response.status_code == 404
     payload = response.json()
-    assert payload["error"]["details"]["errorCode"] == "TRAINING_RUN_NOT_FOUND"
+    assert payload["error"]["details"]["errorCode"] == "TRAINING_JOB_NOT_FOUND"
 
 
 @pytest.mark.anyio
-async def test_training_abort_unknown_run(async_client):
-    response = await async_client.post("/train/abort", json={"runId": "missing"})
+async def test_training_abort_unknown_job(async_client):
+    response = await async_client.post("/api/v1/train/abort", json={"jobId": "missing"})
     assert response.status_code == 404
     payload = response.json()
-    assert payload["error"]["details"]["errorCode"] == "TRAINING_RUN_NOT_FOUND"
+    assert payload["error"]["details"]["errorCode"] == "TRAINING_JOB_NOT_FOUND"


### PR DESCRIPTION
## Summary
- unify training API behind the /api/v1/train handlers while keeping legacy /train aliases and runId compatibility
- drop redundant legacy request/response models and ensure the controller accepts legacy payloads via root validator
- refresh backend tests and fixtures to cover the consolidated routes and simulated registry metadata

## Testing
- pytest tests/backend -q

------
https://chatgpt.com/codex/tasks/task_e_68d8ed20f8c8832d93bae8c8737c9e48