### PR TITLE
Fix lm-eval package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ torch
 transformers
 peft
 bitsandbytes
-lm_eval
+lm-eval


### PR DESCRIPTION
## Summary
- update the requirements file to use the correct lm-eval package name

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8f3be1a7c832d8fa1882a328c7053