### PR TITLE
Separate optional training dependencies

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,9 +1,17 @@
 FROM python:3.10-slim
 
+ARG INSTALL_TRAINING_DEPS=0
+ENV INSTALL_TRAINING_DEPS=${INSTALL_TRAINING_DEPS}
+
 WORKDIR /app
 
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt requirements-optional.txt ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && if [ "$INSTALL_TRAINING_DEPS" = "1" ]; then \
+        pip install --no-cache-dir -r requirements-optional.txt; \
+    else \
+        echo "Skipping optional training dependencies"; \
+    fi
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ This repository now contains a minimal FastAPI backend with a React/Vite front-e
    pip install -r requirements.txt
    ```
 
+   To include optional GPU/training extras (such as `bitsandbytes`), install both requirement files:
+   ```bash
+   pip install -r requirements.txt -r requirements-optional.txt
+   ```
+
 3. Run the API server:
    ```bash
    uvicorn main:app --host 0.0.0.0 --port 8000 --reload
@@ -97,6 +102,15 @@ To iterate locally with hot-reload enabled, start the stack with the default Com
 ```bash
 docker compose up --build
 ```
+
+Set the `INSTALL_TRAINING_DEPS=1` build argument when you need the optional training stack inside the backend image. For example:
+
+```bash
+docker compose build --build-arg INSTALL_TRAINING_DEPS=1 backend
+docker compose up --build
+```
+
+Alternatively, pass `INSTALL_TRAINING_DEPS=1` as an environment variable (`docker build --build-arg INSTALL_TRAINING_DEPS=1 .`) to pull in the extras during image builds. Leaving the flag unset keeps the image slim.
 
 - Backend: exposed at `http://localhost:8000`
 - Frontend dev server: `http://localhost:3000`

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,2 @@
+# Optional GPU/training extras
+bitsandbytes

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ pytest
 torch
 transformers
 peft
-bitsandbytes
 lm-eval


### PR DESCRIPTION
## Summary
- move GPU-focused dependencies into a new `requirements-optional.txt`
- gate optional installs in the backend Dockerfile behind an `INSTALL_TRAINING_DEPS` flag
- document how to install the training extras locally and during Docker builds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8f47ad870832d967ee35eed01d7ed